### PR TITLE
Revert "DB-3193: Change composer type to `wordpress-plugin`."

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "pantheon-systems/pantheon-decoupled-gatsby",
   "description": "Configuration necessary for using WordPress with Gatsby on Pantheon.",
-  "type": "wordpress-plugin",
+  "type": "wordpress-muplugin",
   "require": {
     "wpackagist-plugin/wp-gatsby": "^2.0",
     "pantheon-systems/pantheon-decoupled": "*"


### PR DESCRIPTION
Reverts pantheon-systems/wp-pantheon-decoupled-gatsby#1